### PR TITLE
chore: add trivy-operator to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Aqua Security Open Source Projects Helm Charts on a [Kubernetes](https://kuberne
 
 ## Charts
 
+- [Trivy Operator](https://github.com/aquasecurity/trivy-operator/tree/main/deploy/helm)
 - [Starboard](https://github.com/aquasecurity/starboard/tree/main/deploy/helm)
 - [Trivy](https://github.com/aquasecurity/trivy/tree/main/helm/trivy)
 


### PR DESCRIPTION
Signed-off-by: Engin Diri <engin.diri@mail.schwarz>

Hi,

added the `triy-operator` to the README.md so the https://aquasecurity.github.io/helm-charts/ page shows the lkink to the `triy-operator`

![image](https://user-images.githubusercontent.com/38325136/179703390-abc4c3ab-dd07-4be0-b816-fe77724f6c1c.png)
