### PR TITLE
docs: add postee to github page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Aqua Security Open Source Projects Helm Charts on a [Kubernetes](https://kuberne
 - [Trivy Operator](https://github.com/aquasecurity/trivy-operator/tree/main/deploy/helm)
 - [Starboard](https://github.com/aquasecurity/starboard/tree/main/deploy/helm)
 - [Trivy](https://github.com/aquasecurity/trivy/tree/main/helm/trivy)
+- [Postee](https://github.com/aquasecurity/postee/tree/main/deploy/helm/postee)
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description
https://aquasecurity.github.io/helm-charts/ doesn't contain `Postee`.
![image](https://github.com/aquasecurity/helm-charts/assets/91113035/b7e9163b-30da-4588-ae4a-ffb6c113f24b)


If i understand correctly we also need to add Postee to README.MD in `gh-pages` branch.

## Related PRs
- [x] #5 