### PR TITLE
ci: add full clone of the published repository

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -65,7 +65,6 @@ jobs:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
           persist-credentials: false
-          sparse-checkout: ${{ inputs.chart_dir }}
 
       - name: Install chart-releaser
         env:


### PR DESCRIPTION
## Description
The starboard repository uses symlinks to reference CustomResourceDefinition files instead of duplicating them. While this approach avoids redundancy, it is incompatible with `sparse-checkout`, which does not resolve symlinks to files outside the checked-out subtree.

Replace sparse-checkout with a full clone of the repository, ensuring all symlinks are properly resolved and CRD files are available during the pipeline execution.

It was tested inside my fork: https://github.com/afdesk/helm-charts/actions/runs/26557656906

Before (https://github.com/afdesk/helm-charts/actions/runs/26557147943/job/78231307461):
```sh
Error: error evaluating symlink /home/runner/work/helm-charts/helm-charts/deploy/helm/crds: lstat /home/runner/work/helm-charts/helm-charts/deploy/crd: no such file or directory
Usage:
  cr package [CHART_PATH] [...] [flags]

Flags:
  -h, --help                     help for package
      --key string               Name of the key to use when signing
      --keyring string           Location of a public keyring (default "/home/runner/.gnupg/pubring.gpg")
  -p, --package-path string      Path to directory with chart packages (default ".cr-release-packages")
      --passphrase-file string   Location of a file which contains the passphrase for the signing key. Use '-' in order to read from stdin
      --sign                     Use a PGP private key to sign this package

Global Flags:
      --config string   Config file (default is $HOME/.cr.yaml)

Error: Process completed with exit code 1.

```

After (https://github.com/afdesk/helm-charts/actions/runs/26557656906):
```sh
2026/05/28 06:00:23 found symbolic link in path: /home/runner/work/helm-charts/helm-charts/deploy/helm/crds resolves to /home/runner/work/helm-charts/helm-charts/deploy/crd
2026/05/28 06:00:23 found symbolic link in path: /home/runner/work/helm-charts/helm-charts/deploy/helm/templates/specs resolves to /home/runner/work/helm-charts/helm-charts/deploy/specs
2026/05/28 06:00:23 found symbolic link in path: /home/runner/work/helm-charts/helm-charts/deploy/helm/crds resolves to /home/runner/work/helm-charts/helm-charts/deploy/crd
2026/05/28 06:00:23 found symbolic link in path: /home/runner/work/helm-charts/helm-charts/deploy/helm/templates/specs resolves to /home/runner/work/helm-charts/helm-charts/deploy/specs
2026/05/28 06:00:23 found symbolic link in path: /home/runner/work/helm-charts/helm-charts/deploy/helm/crds resolves to /home/runner/work/helm-charts/helm-charts/deploy/crd
2026/05/28 06:00:23 found symbolic link in path: /home/runner/work/helm-charts/helm-charts/deploy/helm/templates/specs resolves to /home/runner/work/helm-charts/helm-charts/deploy/specs
Successfully packaged chart in /home/runner/work/helm-charts/helm-charts/deploy/helm and saved it to: .cr-release-packages/starboard-operator-0.10.23.tgz

```