### PR TITLE
ci: use actions@github.com as git bot email

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -131,7 +131,7 @@ jobs:
           cp index.yaml gh-pages/index.yaml
           cd gh-pages
           git config user.name "GitHub Actions"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.email "actions@github.com"
           BRANCH="update-index-${CHART_TAG}"
           git checkout -b "${BRANCH}"
           git add index.yaml


### PR DESCRIPTION
The bot's email address has been changed to bypass the CLA signature check. This is the same as in https://github.com/aquasecurity/trivy-action/pull/561. Verified at https://github.com/aquasecurity/helm-charts/pull/15